### PR TITLE
add charset to request Content-Type

### DIFF
--- a/apiai.go
+++ b/apiai.go
@@ -67,7 +67,7 @@ func Response(query QueryStruct, api APIAI) (ResponseStruct, error) {
 	if err != nil {
 		return ResponseStruct{}, err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", "Bearer "+api.AuthToken)
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
If we want to post query by 日本語(Japanese), api.ai needs charset.